### PR TITLE
Read all host information (except network related) from /host/proc/ i…

### DIFF
--- a/src/libs/zbxsysinfo/common/common.c
+++ b/src/libs/zbxsysinfo/common/common.c
@@ -45,7 +45,7 @@ void add_allowed_path(char *config_value) {
 }
 
 #if !defined(_WINDOWS)
-#	define VFS_TEST_FILE "/etc/passwd"
+#	define VFS_TEST_FILE "/host/etc/passwd"
 #	define VFS_TEST_REGEXP "root"
 #else
 #	define VFS_TEST_FILE "c:\\windows\\win.ini"

--- a/src/libs/zbxsysinfo/linux/boottime.c
+++ b/src/libs/zbxsysinfo/linux/boottime.c
@@ -30,9 +30,9 @@ int	SYSTEM_BOOTTIME(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (NULL == (f = fopen("/proc/stat", "r")))
+	if (NULL == (f = fopen("/host/proc/stat", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/stat: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/stat: %s", zbx_strerror(errno)));
 		return ret;
 	}
 
@@ -51,7 +51,7 @@ int	SYSTEM_BOOTTIME(AGENT_REQUEST *request, AGENT_RESULT *result)
 	zbx_fclose(f);
 
 	if (SYSINFO_RET_FAIL == ret)
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot find a line with \"btime\" in /proc/stat."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot find a line with \"btime\" in /host/proc/stat."));
 
 	return ret;
 }

--- a/src/libs/zbxsysinfo/linux/cpu.c
+++ b/src/libs/zbxsysinfo/linux/cpu.c
@@ -196,9 +196,9 @@ int     SYSTEM_CPU_SWITCHES(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (NULL == (f = fopen("/proc/stat", "r")))
+	if (NULL == (f = fopen("/host/proc/stat", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/stat: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/stat: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -217,7 +217,7 @@ int     SYSTEM_CPU_SWITCHES(AGENT_REQUEST *request, AGENT_RESULT *result)
 	zbx_fclose(f);
 
 	if (SYSINFO_RET_FAIL == ret)
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot find a line with \"ctxt\" in /proc/stat."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot find a line with \"ctxt\" in /host/proc/stat."));
 
 	return ret;
 }
@@ -231,9 +231,9 @@ int     SYSTEM_CPU_INTR(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (NULL == (f = fopen("/proc/stat", "r")))
+	if (NULL == (f = fopen("/host/proc/stat", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/stat: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/stat: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -252,7 +252,7 @@ int     SYSTEM_CPU_INTR(AGENT_REQUEST *request, AGENT_RESULT *result)
 	zbx_fclose(f);
 
 	if (SYSINFO_RET_FAIL == ret)
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot find a line with \"intr\" in /proc/stat."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot find a line with \"intr\" in /host/proc/stat."));
 
 	return ret;
 }

--- a/src/libs/zbxsysinfo/linux/diskio.c
+++ b/src/libs/zbxsysinfo/linux/diskio.c
@@ -27,7 +27,7 @@
 #define ZBX_DEV_WRITE	1
 
 #if defined(KERNEL_2_4)
-#	define INFO_FILE_NAME	"/proc/partitions"
+#	define INFO_FILE_NAME	"/host/proc/partitions"
 #	define PARSE(line)	if (sscanf(line, ZBX_FS_UI64 ZBX_FS_UI64 " %*d %s " 		\
 					ZBX_FS_UI64 " %*d " ZBX_FS_UI64 " %*d "			\
 					ZBX_FS_UI64 " %*d " ZBX_FS_UI64 " %*d %*d %*d %*d",	\
@@ -40,7 +40,7 @@
 				&ds[ZBX_DSTAT_W_SECT]						\
 				) != 7) continue
 #else
-#	define INFO_FILE_NAME	"/proc/diskstats"
+#	define INFO_FILE_NAME	"/host/proc/diskstats"
 #	define PARSE(line)	if (sscanf(line, ZBX_FS_UI64 ZBX_FS_UI64 " %s "			\
 					ZBX_FS_UI64 " %*d " ZBX_FS_UI64 " %*d "			\
 					ZBX_FS_UI64 " %*d " ZBX_FS_UI64 " %*d %*d %*d %*d",	\

--- a/src/libs/zbxsysinfo/linux/diskio.c
+++ b/src/libs/zbxsysinfo/linux/diskio.c
@@ -22,7 +22,7 @@
 #include "stats.h"
 #include "diskdevices.h"
 
-#define ZBX_DEV_PFX	"/dev/"
+#define ZBX_DEV_PFX	"/host/dev/"
 #define ZBX_DEV_READ	0
 #define ZBX_DEV_WRITE	1
 

--- a/src/libs/zbxsysinfo/linux/diskspace.c
+++ b/src/libs/zbxsysinfo/linux/diskspace.c
@@ -132,9 +132,9 @@ int	VFS_FS_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (NULL == (f = fopen("/proc/mounts", "r")))
+	if (NULL == (f = fopen("/host/proc/mounts", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/mounts: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/mounts: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 

--- a/src/libs/zbxsysinfo/linux/hardware.h
+++ b/src/libs/zbxsysinfo/linux/hardware.h
@@ -24,8 +24,8 @@
 #define SMBIOS_STATUS_ERROR	2
 #define SMBIOS_STATUS_OK	3
 
-#define DEV_MEM			"/dev/mem"
-#define SYS_TABLE_FILE		"/sys/firmware/dmi/tables/DMI"
+#define DEV_MEM			"/host/dev/mem"
+#define SYS_TABLE_FILE		"/host/sys/firmware/dmi/tables/DMI"
 #define SMBIOS_ENTRY_POINT_SIZE	0x20
 #define DMI_HEADER_SIZE		4
 
@@ -37,7 +37,7 @@
 #define DMI_GET_MODEL		0x04
 #define DMI_GET_SERIAL		0x08
 
-#define CPU_MAX_FREQ_FILE	"/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq"
+#define CPU_MAX_FREQ_FILE	"/host/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq"
 
 #define HW_CPU_INFO_FILE	"/host/proc/cpuinfo"
 #define HW_CPU_ALL_CPUS		-1

--- a/src/libs/zbxsysinfo/linux/hardware.h
+++ b/src/libs/zbxsysinfo/linux/hardware.h
@@ -39,7 +39,7 @@
 
 #define CPU_MAX_FREQ_FILE	"/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq"
 
-#define HW_CPU_INFO_FILE	"/proc/cpuinfo"
+#define HW_CPU_INFO_FILE	"/host/proc/cpuinfo"
 #define HW_CPU_ALL_CPUS		-1
 #define HW_CPU_SHOW_ALL		1
 #define HW_CPU_SHOW_MAXFREQ	2

--- a/src/libs/zbxsysinfo/linux/kernel.c
+++ b/src/libs/zbxsysinfo/linux/kernel.c
@@ -45,9 +45,9 @@ int	KERNEL_MAXFILES(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (SYSINFO_RET_FAIL == read_uint64_from_procfs("/proc/sys/fs/file-max", &value))
+	if (SYSINFO_RET_FAIL == read_uint64_from_procfs("/host/proc/sys/fs/file-max", &value))
 	{
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain data from /proc/sys/fs/file-max."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain data from /host/proc/sys/fs/file-max."));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -61,9 +61,9 @@ int	KERNEL_MAXPROC(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (SYSINFO_RET_FAIL == read_uint64_from_procfs("/proc/sys/kernel/pid_max", &value))
+	if (SYSINFO_RET_FAIL == read_uint64_from_procfs("/host/proc/sys/kernel/pid_max", &value))
 	{
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain data from /proc/sys/kernel/pid_max."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain data from /host/proc/sys/kernel/pid_max."));
 		return SYSINFO_RET_FAIL;
 	}
 

--- a/src/libs/zbxsysinfo/linux/memory.c
+++ b/src/libs/zbxsysinfo/linux/memory.c
@@ -73,15 +73,15 @@ static int	VM_MEMORY_CACHED(AGENT_RESULT *result)
 	zbx_uint64_t	value;
 	int		res;
 
-	if (NULL == (f = fopen("/proc/meminfo", "r")))
+	if (NULL == (f = fopen("/host/proc/meminfo", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/meminfo: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/meminfo: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
 	if (FAIL == (res = byte_value_from_proc_file(f, "Cached:", NULL, &value)))
 	{
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain the value of Cached from /proc/meminfo."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain the value of Cached from /host/proc/meminfo."));
 		goto close;
 	}
 
@@ -140,15 +140,15 @@ static int	VM_MEMORY_AVAILABLE(AGENT_RESULT *result)
 
 	/* try MemAvailable (present since Linux 3.14), falling back to a calculation based on sysinfo() and Cached */
 
-	if (NULL == (f = fopen("/proc/meminfo", "r")))
+	if (NULL == (f = fopen("/host/proc/meminfo", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/meminfo: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/meminfo: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
 	if (FAIL == (res = byte_value_from_proc_file(f, "MemAvailable:", "Cached:", &value)))
 	{
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain the value of MemAvailable from /proc/meminfo."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain the value of MemAvailable from /host/proc/meminfo."));
 		goto close;
 	}
 
@@ -161,7 +161,7 @@ static int	VM_MEMORY_AVAILABLE(AGENT_RESULT *result)
 
 	if (FAIL == (res = byte_value_from_proc_file(f, "Cached:", NULL, &value)))
 	{
-		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain the value of Cached from /proc/meminfo."));
+		SET_MSG_RESULT(result, zbx_strdup(NULL, "Cannot obtain the value of Cached from /host/proc/meminfo."));
 		goto close;
 	}
 

--- a/src/libs/zbxsysinfo/linux/net.c
+++ b/src/libs/zbxsysinfo/linux/net.c
@@ -211,9 +211,9 @@ static int	get_net_stat(const char *if_name, net_stat_t *result, char **error)
 		return SYSINFO_RET_FAIL;
 	}
 
-	if (NULL == (f = fopen("/proc/net/dev", "r")))
+	if (NULL == (f = fopen("/host/proc/net/dev", "r")))
 	{
-		*error = zbx_dsprintf(NULL, "Cannot open /proc/net/dev: %s", zbx_strerror(errno));
+		*error = zbx_dsprintf(NULL, "Cannot open /host/proc/net/dev: %s", zbx_strerror(errno));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -251,7 +251,7 @@ static int	get_net_stat(const char *if_name, net_stat_t *result, char **error)
 
 	if (SYSINFO_RET_FAIL == ret)
 	{
-		*error = zbx_strdup(NULL, "Cannot find information for this network interface in /proc/net/dev.");
+		*error = zbx_strdup(NULL, "Cannot find information for this network interface in /host/proc/net/dev.");
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -529,9 +529,9 @@ int	NET_IF_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	ZBX_UNUSED(request);
 
-	if (NULL == (f = fopen("/proc/net/dev", "r")))
+	if (NULL == (f = fopen("/host/proc/net/dev", "r")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc/net/dev: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc/net/dev: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -630,11 +630,11 @@ int	NET_TCP_LISTEN(AGENT_REQUEST *request, AGENT_RESULT *result)
 		}
 
 		zabbix_log(LOG_LEVEL_DEBUG, "netlink interface error: %s", error);
-		zabbix_log(LOG_LEVEL_DEBUG, "falling back on reading /proc/net/tcp...");
+		zabbix_log(LOG_LEVEL_DEBUG, "falling back on reading /host/proc/net/tcp...");
 #endif
 		buffer = zbx_malloc(NULL, buffer_alloc);
 
-		if (0 < (n = proc_read_tcp_listen("/proc/net/tcp", &buffer, &buffer_alloc)))
+		if (0 < (n = proc_read_tcp_listen("/host/proc/net/tcp", &buffer, &buffer_alloc)))
 		{
 			ret = SYSINFO_RET_OK;
 
@@ -647,7 +647,7 @@ int	NET_TCP_LISTEN(AGENT_REQUEST *request, AGENT_RESULT *result)
 			}
 		}
 
-		if (0 < (n = proc_read_tcp_listen("/proc/net/tcp6", &buffer, &buffer_alloc)))
+		if (0 < (n = proc_read_tcp_listen("/host/proc/net/tcp6", &buffer, &buffer_alloc)))
 		{
 			ret = SYSINFO_RET_OK;
 
@@ -690,7 +690,7 @@ int	NET_UDP_LISTEN(AGENT_REQUEST *request, AGENT_RESULT *result)
 
 	buffer = zbx_malloc(NULL, buffer_alloc);
 
-	if (0 < (n = proc_read_file("/proc/net/udp", &buffer, &buffer_alloc)))
+	if (0 < (n = proc_read_file("/host/proc/net/udp", &buffer, &buffer_alloc)))
 	{
 		ret = SYSINFO_RET_OK;
 
@@ -705,7 +705,7 @@ int	NET_UDP_LISTEN(AGENT_REQUEST *request, AGENT_RESULT *result)
 		}
 	}
 
-	if (0 < (n = proc_read_file("/proc/net/udp6", &buffer, &buffer_alloc)))
+	if (0 < (n = proc_read_file("/host/proc/net/udp6", &buffer, &buffer_alloc)))
 	{
 		ret = SYSINFO_RET_OK;
 

--- a/src/libs/zbxsysinfo/linux/proc.c
+++ b/src/libs/zbxsysinfo/linux/proc.c
@@ -120,7 +120,7 @@ static int	check_procname(FILE *f_cmd, FILE *f_stat, const char *procname)
 	if (NULL == procname || '\0' == *procname)
 		return SUCCEED;
 
-	/* process name in /proc/[pid]/status contains limited number of characters */
+	/* process name in /host/proc/[pid]/status contains limited number of characters */
 	if (SUCCEED == cmp_status(f_stat, procname))
 		return SUCCEED;
 
@@ -323,7 +323,7 @@ static int	get_total_memory(zbx_uint64_t *total_memory)
 	FILE	*f;
 	int	ret = FAIL;
 
-	if (NULL != (f = fopen("/proc/meminfo", "r")))
+	if (NULL != (f = fopen("/host/proc/meminfo", "r")))
 	{
 		ret = byte_value_from_proc_file(f, "MemTotal:", NULL, total_memory);
 		zbx_fclose(f);
@@ -506,9 +506,9 @@ int	PROC_MEM(AGENT_REQUEST *request, AGENT_RESULT *result)
 		}
 	}
 
-	if (NULL == (dir = opendir("/proc")))
+	if (NULL == (dir = opendir("/host/proc")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -520,12 +520,12 @@ int	PROC_MEM(AGENT_REQUEST *request, AGENT_RESULT *result)
 		if (0 == strcmp(entries->d_name, "self"))
 			continue;
 
-		zbx_snprintf(tmp, sizeof(tmp), "/proc/%s/cmdline", entries->d_name);
+		zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%s/cmdline", entries->d_name);
 
 		if (NULL == (f_cmd = fopen(tmp, "r")))
 			continue;
 
-		zbx_snprintf(tmp, sizeof(tmp), "/proc/%s/status", entries->d_name);
+		zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%s/status", entries->d_name);
 
 		if (NULL == (f_stat = fopen(tmp, "r")))
 			continue;
@@ -769,9 +769,9 @@ int	PROC_NUM(AGENT_REQUEST *request, AGENT_RESULT *result)
 	if (1 == invalid_user)	/* handle 0 for non-existent user after all parameters have been parsed and validated */
 		goto out;
 
-	if (NULL == (dir = opendir("/proc")))
+	if (NULL == (dir = opendir("/host/proc")))
 	{
-		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /proc: %s", zbx_strerror(errno)));
+		SET_MSG_RESULT(result, zbx_dsprintf(NULL, "Cannot open /host/proc: %s", zbx_strerror(errno)));
 		return SYSINFO_RET_FAIL;
 	}
 
@@ -783,12 +783,12 @@ int	PROC_NUM(AGENT_REQUEST *request, AGENT_RESULT *result)
 		if (0 == strcmp(entries->d_name, "self"))
 			continue;
 
-		zbx_snprintf(tmp, sizeof(tmp), "/proc/%s/cmdline", entries->d_name);
+		zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%s/cmdline", entries->d_name);
 
 		if (NULL == (f_cmd = fopen(tmp, "r")))
 			continue;
 
-		zbx_snprintf(tmp, sizeof(tmp), "/proc/%s/status", entries->d_name);
+		zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%s/status", entries->d_name);
 
 		if (NULL == (f_stat = fopen(tmp, "r")))
 			continue;
@@ -837,7 +837,7 @@ static int	proc_get_process_name(pid_t pid, char **procname)
 	int	n, fd;
 	char	tmp[MAX_STRING_LEN], *pend, *pstart;
 
-	zbx_snprintf(tmp, sizeof(tmp), "/proc/%d/stat", (int)pid);
+	zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%d/stat", (int)pid);
 
 	if (-1 == (fd = open(tmp, O_RDONLY)))
 		return FAIL;
@@ -885,7 +885,7 @@ static int	proc_get_process_cmdline(pid_t pid, char **cmdline, size_t *cmdline_n
 	size_t	cmdline_alloc = ZBX_KIBIBYTE;
 
 	*cmdline_nbytes = 0;
-	zbx_snprintf(tmp, sizeof(tmp), "/proc/%d/cmdline", (int)pid);
+	zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%d/cmdline", (int)pid);
 
 	if (-1 == (fd = open(tmp, O_RDONLY)))
 		return FAIL;
@@ -946,7 +946,7 @@ static int	proc_get_process_uid(pid_t pid, uid_t *uid)
 	char		tmp[MAX_STRING_LEN];
 	zbx_stat_t	st;
 
-	zbx_snprintf(tmp, sizeof(tmp), "/proc/%d", (int)pid);
+	zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%d", (int)pid);
 
 	if (0 != zbx_stat(tmp, &st))
 		return FAIL;
@@ -1003,7 +1003,7 @@ static int	proc_read_cpu_util(zbx_procstat_util_t *procutil)
 	int	n, offset, fd, ret = SUCCEED;
 	char	tmp[MAX_STRING_LEN], *ptr;
 
-	zbx_snprintf(tmp, sizeof(tmp), "/proc/%d/stat", (int)procutil->pid);
+	zbx_snprintf(tmp, sizeof(tmp), "/host/proc/%d/stat", (int)procutil->pid);
 
 	if (-1 == (fd = open(tmp, O_RDONLY)))
 		return -errno;
@@ -1247,7 +1247,7 @@ int	zbx_proc_get_processes(zbx_vector_ptr_t *processes, unsigned int flags)
 
 	zabbix_log(LOG_LEVEL_TRACE, "In %s()", __function_name);
 
-	if (NULL == (dir = opendir("/proc")))
+	if (NULL == (dir = opendir("/host/proc")))
 		goto out;
 
 	while (NULL != (entries = readdir(dir)))

--- a/src/libs/zbxsysinfo/linux/sensors.c
+++ b/src/libs/zbxsysinfo/linux/sensors.c
@@ -21,7 +21,7 @@
 #include "zbxregexp.h"
 
 #ifdef KERNEL_2_4
-#define DEVICE_DIR	"/proc/sys/dev/sensors"
+#define DEVICE_DIR	"/host/proc/sys/dev/sensors"
 #else
 #define DEVICE_DIR	"/sys/class/hwmon"
 static char	*locations[] = {"", "/device", NULL};

--- a/src/libs/zbxsysinfo/linux/sensors.c
+++ b/src/libs/zbxsysinfo/linux/sensors.c
@@ -23,7 +23,7 @@
 #ifdef KERNEL_2_4
 #define DEVICE_DIR	"/host/proc/sys/dev/sensors"
 #else
-#define DEVICE_DIR	"/sys/class/hwmon"
+#define DEVICE_DIR	"/host/sys/class/hwmon"
 static char	*locations[] = {"", "/device", NULL};
 #endif
 
@@ -181,7 +181,7 @@ static int	get_device_info(const char *dev_path, const char *dev_name, char *dev
 		}
 		else
 		{
-			zbx_snprintf(bus_path, sizeof(bus_path), "/sys/class/i2c-adapter/i2c-%d", bus_i2c);
+			zbx_snprintf(bus_path, sizeof(bus_path), "/host/sys/class/i2c-adapter/i2c-%d", bus_i2c);
 			bus_subfolder = sysfs_read_attr(bus_path, &bus_attr);
 
 			if (NULL != bus_subfolder && '\0' != *bus_subfolder)

--- a/src/libs/zbxsysinfo/linux/software.h
+++ b/src/libs/zbxsysinfo/linux/software.h
@@ -20,8 +20,8 @@
 #ifndef ZABBIX_SOFTWARE_H
 #define ZABBIX_SOFTWARE_H
 
-#define SW_OS_FULL			"/proc/version"
-#define SW_OS_SHORT 			"/proc/version_signature"
+#define SW_OS_FULL			"/host/proc/version"
+#define SW_OS_SHORT 			"/host/proc/version_signature"
 #define SW_OS_NAME			"/etc/issue.net"
 #define SW_OS_NAME_RELEASE		"/etc/os-release"
 

--- a/src/libs/zbxsysinfo/linux/software.h
+++ b/src/libs/zbxsysinfo/linux/software.h
@@ -22,8 +22,8 @@
 
 #define SW_OS_FULL			"/host/proc/version"
 #define SW_OS_SHORT 			"/host/proc/version_signature"
-#define SW_OS_NAME			"/etc/issue.net"
-#define SW_OS_NAME_RELEASE		"/etc/os-release"
+#define SW_OS_NAME			"/host/etc/issue.net"
+#define SW_OS_NAME_RELEASE		"/host/etc/os-release"
 
 #define SW_OS_OPTION_PRETTY_NAME	"PRETTY_NAME"
 

--- a/src/libs/zbxsysinfo/linux/swap.c
+++ b/src/libs/zbxsysinfo/linux/swap.c
@@ -215,7 +215,7 @@ static int	get_swap_stat(const char *swapdev, swap_stat_t *result)
 		ret = get_swap_pages(result);
 		swapdev = NULL;
 	}
-	else if (0 != strncmp(swapdev, "/dev/", 5))
+	else if (0 != strncmp(swapdev, "/host/dev/", 5))
 		offset = 5;
 
 	if (NULL == (f = fopen("/host/proc/swaps", "r")))
@@ -223,7 +223,7 @@ static int	get_swap_stat(const char *swapdev, swap_stat_t *result)
 
 	while (NULL != fgets(line, sizeof(line), f))
 	{
-		if (0 != strncmp(line, "/dev/", 5))
+		if (0 != strncmp(line, "/host/dev/", 5))
 			continue;
 
 		if (NULL == (s = strchr(line, ' ')))

--- a/src/libs/zbxsysinfo/linux/swap.c
+++ b/src/libs/zbxsysinfo/linux/swap.c
@@ -78,7 +78,7 @@ typedef struct
 swap_stat_t;
 
 #ifdef KERNEL_2_4
-#	define INFO_FILE_NAME	"/proc/partitions"
+#	define INFO_FILE_NAME	"/host/proc/partitions"
 #	define PARSE(line)								\
 											\
 		if (6 != sscanf(line, "%d %d %*d %*s "					\
@@ -92,7 +92,7 @@ swap_stat_t;
 				&result->wsect		/* wsect */			\
 				)) continue
 #else
-#	define INFO_FILE_NAME	"/proc/diskstats"
+#	define INFO_FILE_NAME	"/host/proc/diskstats"
 #	define PARSE(line)								\
 											\
 		if (6 != sscanf(line, "%d %d %*s "					\
@@ -158,9 +158,9 @@ static int	get_swap_pages(swap_stat_t *result)
 	FILE	*f;
 
 #ifdef KERNEL_2_4
-	if (NULL != (f = fopen("/proc/stat", "r")))
+	if (NULL != (f = fopen("/host/proc/stat", "r")))
 #else
-	if (NULL != (f = fopen("/proc/vmstat", "r")))
+	if (NULL != (f = fopen("/host/proc/vmstat", "r")))
 #endif
 	{
 		while (NULL != fgets(line, sizeof(line), f))
@@ -218,7 +218,7 @@ static int	get_swap_stat(const char *swapdev, swap_stat_t *result)
 	else if (0 != strncmp(swapdev, "/dev/", 5))
 		offset = 5;
 
-	if (NULL == (f = fopen("/proc/swaps", "r")))
+	if (NULL == (f = fopen("/host/proc/swaps", "r")))
 		return ret;
 
 	while (NULL != fgets(line, sizeof(line), f))

--- a/src/zabbix_agent/cpustat.c
+++ b/src/zabbix_agent/cpustat.c
@@ -315,7 +315,7 @@ static void	update_cpustats(ZBX_CPUS_STAT_DATA *pcpus)
 	FILE		*file;
 	char		line[1024];
 	unsigned char	*cpu_status = NULL;
-	const char	*filename = "/proc/stat";
+	const char	*filename = "/host/proc/stat";
 
 #elif defined(HAVE_SYS_PSTAT_H)
 

--- a/src/zabbix_agent/stats.c
+++ b/src/zabbix_agent/stats.c
@@ -102,7 +102,7 @@ static int	zbx_get_cpu_num()
 	FILE	*f = NULL;
 	int	ncpu = 0;
 
-	if (NULL == (file = fopen("/proc/cpuinfo", "r")))
+	if (NULL == (file = fopen("/host/proc/cpuinfo", "r")))
 		goto return_one;
 
 	while (NULL != fgets(line, 1024, file))


### PR DESCRIPTION
…nstead of /proc/ to allow monitoring host from inside a docker container

Reapplied manually bhuisgen's coreos monitoring patch (https://github.com/digiapulssi/docker-zabbix-coreos/blob/master/files/coreos.patch) to Zabbix agent version 3.2

Left out network related path ie. /proc/net because I'm going to enforce usage of host network stack (--network=host) for the container, to enable host network adapter discovery and monitoring